### PR TITLE
fix(sequence): do not call EncodeTuple

### DIFF
--- a/sequence.go
+++ b/sequence.go
@@ -9,7 +9,6 @@ package goscale
 
 import (
 	"bytes"
-	"reflect"
 )
 
 type Sequence[T Encodable] []T
@@ -18,11 +17,11 @@ func (seq Sequence[Encodable]) Encode(buffer *bytes.Buffer) {
 	ToCompact(len(seq)).Encode(buffer)
 
 	for _, v := range seq {
-		if reflect.TypeOf(v).Kind() == reflect.Struct {
-			EncodeTuple(v, buffer)
-		} else {
-			v.Encode(buffer)
-		}
+		//if reflect.TypeOf(v).Kind() == reflect.Struct {
+		//	EncodeTuple(v, buffer)
+		//} else {
+		v.Encode(buffer)
+		//}
 	}
 }
 
@@ -73,11 +72,11 @@ func NewFixedSequence[T Encodable](size int, values ...T) FixedSequence[T] {
 
 func (fseq FixedSequence[T]) Encode(buffer *bytes.Buffer) {
 	for _, v := range fseq {
-		if reflect.TypeOf(v).Kind() == reflect.Struct {
-			EncodeTuple(v, buffer)
-		} else {
-			v.Encode(buffer)
-		}
+		//if reflect.TypeOf(v).Kind() == reflect.Struct {
+		//	EncodeTuple(v, buffer)
+		//} else {
+		v.Encode(buffer)
+		//}
 	}
 }
 

--- a/sequence_test.go
+++ b/sequence_test.go
@@ -321,43 +321,44 @@ func Test_EncodeResultSequence(t *testing.T) {
 	}
 }
 
-func Test_EncodeTupleExampleSequence(t *testing.T) {
-	type TupleBoolU8Str struct {
-		Tuple
-		A0 Bool
-		A1 U8
-		A2 Str
-	}
-
-	var testExamples = []struct {
-		label       string
-		input       Sequence[TupleBoolU8Str]
-		expectation []byte
-	}{
-		{
-			label: "(Sequence[TupleBoolU8Str])",
-			input: Sequence[TupleBoolU8Str]{
-				TupleBoolU8Str{A0: true, A1: 3, A2: "abc"},
-				TupleBoolU8Str{A0: false, A1: 5, A2: "xyz"},
-			},
-			expectation: []byte{
-				0x08,
-				0x01, 0x03, 0x0c, 0x61, 0x062, 0x63,
-				0x00, 0x05, 0x0c, 0x78, 0x79, 0x7a,
-			},
-		},
-	}
-
-	for _, testExample := range testExamples {
-		t.Run(testExample.label, func(t *testing.T) {
-			buffer := &bytes.Buffer{}
-
-			testExample.input.Encode(buffer)
-
-			assertEqual(t, buffer.Bytes(), testExample.expectation)
-		})
-	}
-}
+// TODO: Uncomment once sequences use EncodeTuple
+//func Test_EncodeTupleExampleSequence(t *testing.T) {
+//	type TupleBoolU8Str struct {
+//		Tuple
+//		A0 Bool
+//		A1 U8
+//		A2 Str
+//	}
+//
+//	var testExamples = []struct {
+//		label       string
+//		input       Sequence[TupleBoolU8Str]
+//		expectation []byte
+//	}{
+//		{
+//			label: "(Sequence[TupleBoolU8Str])",
+//			input: Sequence[TupleBoolU8Str]{
+//				TupleBoolU8Str{A0: true, A1: 3, A2: "abc"},
+//				TupleBoolU8Str{A0: false, A1: 5, A2: "xyz"},
+//			},
+//			expectation: []byte{
+//				0x08,
+//				0x01, 0x03, 0x0c, 0x61, 0x062, 0x63,
+//				0x00, 0x05, 0x0c, 0x78, 0x79, 0x7a,
+//			},
+//		},
+//	}
+//
+//	for _, testExample := range testExamples {
+//		t.Run(testExample.label, func(t *testing.T) {
+//			buffer := &bytes.Buffer{}
+//
+//			testExample.input.Encode(buffer)
+//
+//			assertEqual(t, buffer.Bytes(), testExample.expectation)
+//		})
+//	}
+//}
 
 func Test_EncodeStringSequence(t *testing.T) {
 	var testExamples = []struct {


### PR DESCRIPTION
**Detailed description**:
* do not call EncodeTuple as https://github.com/LimeChain/goscale/issues/70

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated