### PR TITLE
Refactor numeric types

### DIFF
--- a/boolean.go
+++ b/boolean.go
@@ -9,7 +9,6 @@ package goscale
 
 import (
 	"bytes"
-	"fmt"
 )
 
 type Bool bool
@@ -39,8 +38,4 @@ func DecodeBool(buffer *bytes.Buffer) Bool {
 	default:
 		panic("invalid bool representation")
 	}
-}
-
-func (value Bool) String() string {
-	return fmt.Sprint(bool(value))
 }

--- a/fixed_length.go
+++ b/fixed_length.go
@@ -10,7 +10,6 @@ package goscale
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"math/big"
 )
 
@@ -32,10 +31,6 @@ func DecodeU8(buffer *bytes.Buffer) U8 {
 	return U8(result[0])
 }
 
-func (value U8) String() string {
-	return fmt.Sprintf("%c", uint8(value))
-}
-
 type I8 int8
 
 func (value I8) Encode(buffer *bytes.Buffer) {
@@ -49,10 +44,6 @@ func (value I8) Bytes() []byte {
 func DecodeI8(buffer *bytes.Buffer) I8 {
 	decoder := Decoder{Reader: buffer}
 	return I8(decoder.DecodeByte())
-}
-
-func (value I8) String() string {
-	return fmt.Sprint(int8(value))
 }
 
 type U16 uint16
@@ -76,10 +67,6 @@ func DecodeU16(buffer *bytes.Buffer) U16 {
 	return U16(binary.LittleEndian.Uint16(result))
 }
 
-func (value U16) String() string {
-	return fmt.Sprint(uint16(value))
-}
-
 type I16 int16
 
 func (value I16) Encode(buffer *bytes.Buffer) {
@@ -92,10 +79,6 @@ func (value I16) Bytes() []byte {
 
 func DecodeI16(buffer *bytes.Buffer) I16 {
 	return I16(DecodeU16(buffer))
-}
-
-func (value I16) String() string {
-	return fmt.Sprint(int16(value))
 }
 
 type U32 uint32
@@ -119,10 +102,6 @@ func DecodeU32(buffer *bytes.Buffer) U32 {
 	return U32(binary.LittleEndian.Uint32(result))
 }
 
-func (value U32) String() string {
-	return fmt.Sprint(uint32(value))
-}
-
 type I32 int32
 
 func (value I32) Encode(buffer *bytes.Buffer) {
@@ -135,10 +114,6 @@ func (value I32) Bytes() []byte {
 
 func DecodeI32(buffer *bytes.Buffer) I32 {
 	return I32(DecodeU32(buffer))
-}
-
-func (value I32) String() string {
-	return fmt.Sprint(int32(value))
 }
 
 type U64 uint64
@@ -162,10 +137,6 @@ func DecodeU64(buffer *bytes.Buffer) U64 {
 	return U64(binary.LittleEndian.Uint64(result))
 }
 
-func (value U64) String() string {
-	return fmt.Sprint(uint64(value))
-}
-
 type I64 int64
 
 func (value I64) Encode(buffer *bytes.Buffer) {
@@ -178,10 +149,6 @@ func (value I64) Bytes() []byte {
 
 func DecodeI64(buffer *bytes.Buffer) I64 {
 	return I64(DecodeU64(buffer))
-}
-
-func (value I64) String() string {
-	return fmt.Sprint(int64(value))
 }
 
 type U128 [2]U64

--- a/fixed_length.go
+++ b/fixed_length.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"math/big"
+	"reflect"
 )
 
 type U8 uint8
@@ -266,5 +267,33 @@ func DecodeI128(buffer *bytes.Buffer) I128 {
 	return I128{
 		DecodeU64(buffer),
 		DecodeU64(buffer),
+	}
+}
+
+func DecodeNumeric[N Numeric](buffer *bytes.Buffer) N {
+	switch reflect.TypeOf(*new(N)) {
+	case reflect.TypeOf(*new(U8)):
+		return N(DecodeU8(buffer))
+	case reflect.TypeOf(*new(I8)):
+		return N(DecodeI8(buffer))
+	case reflect.TypeOf(*new(U16)):
+		return N(DecodeU16(buffer))
+	case reflect.TypeOf(*new(I16)):
+		return N(DecodeI16(buffer))
+	case reflect.TypeOf(*new(U32)):
+		return N(DecodeU32(buffer))
+	case reflect.TypeOf(*new(I32)):
+		return N(DecodeI32(buffer))
+	case reflect.TypeOf(*new(U64)):
+		return N(DecodeU64(buffer))
+	case reflect.TypeOf(*new(I64)):
+		return N(DecodeI64(buffer))
+	// TODO: implement
+	// case reflect.TypeOf(*new(U128)):
+	// 	return N(DecodeU128(buffer))
+	// case reflect.TypeOf(*new(I128)):
+	// 	return N(DecodeI128(buffer))
+	default:
+		panic("unknown numeric type")
 	}
 }

--- a/fixed_length.go
+++ b/fixed_length.go
@@ -270,30 +270,31 @@ func DecodeI128(buffer *bytes.Buffer) I128 {
 	}
 }
 
-func DecodeNumeric[N Numeric](buffer *bytes.Buffer) N {
-	switch reflect.TypeOf(*new(N)) {
-	case reflect.TypeOf(*new(U8)):
-		return N(DecodeU8(buffer))
-	case reflect.TypeOf(*new(I8)):
-		return N(DecodeI8(buffer))
-	case reflect.TypeOf(*new(U16)):
-		return N(DecodeU16(buffer))
-	case reflect.TypeOf(*new(I16)):
-		return N(DecodeI16(buffer))
-	case reflect.TypeOf(*new(U32)):
-		return N(DecodeU32(buffer))
-	case reflect.TypeOf(*new(I32)):
-		return N(DecodeI32(buffer))
-	case reflect.TypeOf(*new(U64)):
-		return N(DecodeU64(buffer))
-	case reflect.TypeOf(*new(I64)):
-		return N(DecodeI64(buffer))
-	// TODO: implement
-	// case reflect.TypeOf(*new(U128)):
-	// 	return N(DecodeU128(buffer))
-	// case reflect.TypeOf(*new(I128)):
-	// 	return N(DecodeI128(buffer))
-	default:
-		panic("unknown numeric type")
+func DecodeNumeric[T Numeric](buffer *bytes.Buffer) T {
+	var result interface{}
+
+	switch reflect.Zero(reflect.TypeOf(*new(T))).Interface().(type) {
+	case U8:
+		result = DecodeU8(buffer)
+	case I8:
+		result = DecodeI8(buffer)
+	case U16:
+		result = DecodeU16(buffer)
+	case I16:
+		result = DecodeI16(buffer)
+	case U32:
+		result = DecodeU32(buffer)
+	case I32:
+		result = DecodeI32(buffer)
+	case U64:
+		result = DecodeU64(buffer)
+	case I64:
+		result = DecodeI64(buffer)
+	case U128:
+		result = DecodeU128(buffer)
+	case I128:
+		result = DecodeI128(buffer)
 	}
+
+	return result.(T)
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,14 +1,6 @@
 package goscale
 
-type UnsignedNumeric interface {
-	U8 | U16 | U32 | U64
-}
-
-type SignedNumeric interface {
-	I8 | I16 | I32 | I64
-}
-
 type Numeric interface {
 	Encodable
-	UnsignedNumeric | SignedNumeric
+	U8 | I8 | U16 | I16 | U32 | I32 | U64 | I64 // TODO | U128 | I128
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,0 +1,14 @@
+package goscale
+
+type UnsignedNumeric interface {
+	U8 | U16 | U32 | U64
+}
+
+type SignedNumeric interface {
+	I8 | I16 | I32 | I64
+}
+
+type Numeric interface {
+	Encodable
+	UnsignedNumeric | SignedNumeric
+}

--- a/numeric_extended.go
+++ b/numeric_extended.go
@@ -20,8 +20,7 @@ var ErrOverflow = errors.New("overflow")
 // package goscale
 // type U8 U8Ext
 
-// TODO: I8, I16, I32, ...
-
+// TODO: I8, I16, I32, I64
 func (a U8) Add(b U8) U8 {
 	return a + b
 }
@@ -217,13 +216,11 @@ func (a U8) SaturatingAdd(b U8) U8 {
 }
 
 func (a U8) SaturatingSub(b U8) U8 {
-	c := a - b
-
-	if c > a {
-		return U8(0)
+	if a > b {
+		return a - b
 	}
 
-	return c
+	return U8(0)
 }
 
 func (a U8) SaturatingMul(b U8) U8 {
@@ -259,13 +256,11 @@ func (a U16) SaturatingAdd(b U16) U16 {
 }
 
 func (a U16) SaturatingSub(b U16) U16 {
-	c := a - b
-
-	if c > a {
-		return U16(0)
+	if a > b {
+		return a - b
 	}
 
-	return c
+	return U16(0)
 }
 
 func (a U16) SaturatingMul(b U16) U16 {
@@ -301,13 +296,11 @@ func (a U32) SaturatingAdd(b U32) U32 {
 }
 
 func (a U32) SaturatingSub(b U32) U32 {
-	c := a - b
-
-	if c > a {
-		return U32(0)
+	if a > b {
+		return a - b
 	}
 
-	return c
+	return U32(0)
 }
 
 func (a U32) SaturatingMul(b U32) U32 {
@@ -343,13 +336,11 @@ func (a U64) SaturatingAdd(b U64) U64 {
 }
 
 func (a U64) SaturatingSub(b U64) U64 {
-	c := a - b
-
-	if c > a {
-		return U64(0)
+	if a > b {
+		return a - b
 	}
 
-	return c
+	return U64(0)
 }
 
 func (a U64) SaturatingMul(b U64) U64 {


### PR DESCRIPTION
**Detailed description**:

* [x] adds common numeric interface and generic decode function
* [x] removes `fmt` package dependency, it is not used anyway
* [ ] `U128` and `I128` do not conform to other numeric types' interfaces (might need to refactor them)

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated