### PR TITLE
refactor(decode): return errors instead of panic

### DIFF
--- a/boolean.go
+++ b/boolean.go
@@ -34,7 +34,10 @@ func (value Bool) Bytes() []byte {
 
 func DecodeBool(buffer *bytes.Buffer) (Bool, error) {
 	decoder := Decoder{Reader: buffer}
-	result := decoder.DecodeByte()
+	result, err := decoder.DecodeByte()
+	if err != nil {
+		return false, err
+	}
 	switch result {
 	case 0:
 		return false, nil

--- a/boolean.go
+++ b/boolean.go
@@ -9,9 +9,14 @@ package goscale
 
 import (
 	"bytes"
+	"errors"
 )
 
 type Bool bool
+
+var (
+	errInvalidBoolRepresentation = errors.New("invalid bool representation")
+)
 
 func (value Bool) Encode(buffer *bytes.Buffer) {
 	encoder := Encoder{Writer: buffer}
@@ -27,15 +32,15 @@ func (value Bool) Bytes() []byte {
 	return buf
 }
 
-func DecodeBool(buffer *bytes.Buffer) Bool {
+func DecodeBool(buffer *bytes.Buffer) (Bool, error) {
 	decoder := Decoder{Reader: buffer}
 	result := decoder.DecodeByte()
 	switch result {
 	case 0:
-		return false
+		return false, nil
 	case 1:
-		return true
+		return true, nil
 	default:
-		panic("invalid bool representation")
+		return false, errInvalidBoolRepresentation
 	}
 }

--- a/boolean_test.go
+++ b/boolean_test.go
@@ -44,7 +44,7 @@ func Test_DecodeBool(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result := DecodeBool(buffer)
+			result, _ := DecodeBool(buffer)
 
 			assert.Equal(t, result, testExample.expectation)
 		})
@@ -67,7 +67,8 @@ func Test_DecodeBoolPanics(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			assert.Panics(t, func() { DecodeBool(buffer) })
+			_, err := DecodeBool(buffer)
+			assert.ErrorIs(t, errInvalidBoolRepresentation, err)
 		})
 	}
 }

--- a/boolean_test.go
+++ b/boolean_test.go
@@ -2,7 +2,7 @@ package goscale
 
 import (
 	"bytes"
-	"errors"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,7 +45,8 @@ func Test_DecodeBool(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result, _ := DecodeBool(buffer)
+			result, err := DecodeBool(buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, testExample.expectation)
 		})
@@ -85,7 +86,7 @@ func Test_DecodeBoolPanics(t *testing.T) {
 			buffer.Write(testExample.input)
 
 			_, err := DecodeBool(buffer)
-			assert.ErrorContains(t, err, errors.New("EOF").Error())
+			assert.ErrorIs(t, err, io.EOF)
 		})
 	}
 }

--- a/boolean_test.go
+++ b/boolean_test.go
@@ -2,6 +2,7 @@ package goscale
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -58,6 +59,12 @@ func Test_DecodeBoolPanics(t *testing.T) {
 	}{
 		{label: "(0xff)", input: []byte{0xff}},
 		{label: "(0x3)", input: []byte{0x3}},
+	}
+
+	var testExamplesEmpty = []struct {
+		label string
+		input []byte
+	}{
 		{label: "([])", input: []byte{}},
 		{label: "(nil)", input: nil},
 	}
@@ -69,6 +76,16 @@ func Test_DecodeBoolPanics(t *testing.T) {
 
 			_, err := DecodeBool(buffer)
 			assert.ErrorIs(t, errInvalidBoolRepresentation, err)
+		})
+	}
+
+	for _, testExample := range testExamplesEmpty {
+		t.Run(testExample.label, func(t *testing.T) {
+			buffer := &bytes.Buffer{}
+			buffer.Write(testExample.input)
+
+			_, err := DecodeBool(buffer)
+			assert.ErrorContains(t, err, errors.New("EOF").Error())
 		})
 	}
 }

--- a/codec.go
+++ b/codec.go
@@ -48,8 +48,11 @@ func (enc Encoder) EncodeByte(b byte) {
 	enc.Write(buf[:1])
 }
 
-func (dec Decoder) DecodeByte() byte {
+func (dec Decoder) DecodeByte() (byte, error) {
 	buf := make([]byte, 1)
-	dec.Read(buf[:1])
-	return buf[0]
+	err := dec.Read(buf[:1])
+	if err != nil {
+		return 0, err
+	}
+	return buf[0], nil
 }

--- a/codec.go
+++ b/codec.go
@@ -8,6 +8,7 @@ Substrate Ref - https://docs.substrate.io/reference/scale-codec/
 package goscale
 
 import (
+	"errors"
 	"io"
 	"strconv"
 )
@@ -30,14 +31,15 @@ func (enc Encoder) Write(bytes []byte) {
 	}
 }
 
-func (dec Decoder) Read(bytes []byte) {
+func (dec Decoder) Read(bytes []byte) error {
 	n, err := dec.Reader.Read(bytes)
 	if err != nil {
-		panic(err.Error())
+		return err
 	}
 	if n < len(bytes) {
-		panic("can not read the required number of bytes " + strconv.Itoa(len(bytes)) + ", only " + strconv.Itoa(n) + " available")
+		return errors.New("can not read the required number of bytes " + strconv.Itoa(len(bytes)) + ", only " + strconv.Itoa(n) + " available")
 	}
+	return nil
 }
 
 func (enc Encoder) EncodeByte(b byte) {

--- a/compact.go
+++ b/compact.go
@@ -9,7 +9,13 @@ package goscale
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"math/big"
+)
+
+var (
+	errCouldNotDecodeCompact = errors.New("could not decode compact")
+	errNotSupported          = errors.New("not supported: n>63 encountered when decoding a compact-encoded uint")
 )
 
 type Compact U128
@@ -71,35 +77,35 @@ func (c Compact) Bytes() []byte {
 	return append([]byte{(topSixBits << 2) + 3}, b...)
 }
 
-func DecodeCompact(buffer *bytes.Buffer) Compact {
+func DecodeCompact(buffer *bytes.Buffer) (Compact, error) {
 	decoder := Decoder{Reader: buffer}
 	result := make([]byte, 16)
 	b := decoder.DecodeByte()
 	mode := b & 3
 	switch mode {
 	case 0:
-		return Compact(NewU128(big.NewInt(0).SetUint64(uint64(b >> 2))))
+		return Compact(NewU128(big.NewInt(0).SetUint64(uint64(b >> 2)))), nil
 	case 1:
 		r := uint64(decoder.DecodeByte())
 		r <<= 6
 		r += uint64(b >> 2)
-		return Compact(NewU128(big.NewInt(0).SetUint64(r)))
+		return Compact(NewU128(big.NewInt(0).SetUint64(r))), nil
 	case 2:
 		buf := result[:4]
 		buf[0] = b
 		decoder.Read(result[1:4])
 		r := binary.LittleEndian.Uint32(buf)
 		r >>= 2
-		return Compact(NewU128(big.NewInt(0).SetUint64(uint64(r))))
+		return Compact(NewU128(big.NewInt(0).SetUint64(uint64(r)))), nil
 	case 3:
 		n := b >> 2
 		if n > 63 {
-			panic("not supported: n>63 encountered when decoding a compact-encoded uint")
+			return Compact(NewU128(0)), errNotSupported
 		}
 		decoder.Read(result[:n+4])
 		reverseSlice(result)
-		return Compact(NewU128(big.NewInt(0).SetBytes(result)))
+		return Compact(NewU128(big.NewInt(0).SetBytes(result))), nil
 	default:
-		panic("code should be unreachable")
+		return Compact(NewU128(0)), errCouldNotDecodeCompact
 	}
 }

--- a/compact_test.go
+++ b/compact_test.go
@@ -82,7 +82,8 @@ func Test_Decode_Compact(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeCompact(buffer)
+			result, err := DecodeCompact(buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 		})

--- a/compact_test.go
+++ b/compact_test.go
@@ -82,7 +82,7 @@ func Test_Decode_Compact(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeCompact(buffer)
+			result, _ := DecodeCompact(buffer)
 
 			assert.Equal(t, result, e.expect)
 		})

--- a/dictionary.go
+++ b/dictionary.go
@@ -41,15 +41,21 @@ func (d Dictionary[K, V]) Bytes() []byte {
 func DecodeDictionary[K Comparable, V Encodable](buffer *bytes.Buffer) (Dictionary[K, V], error) {
 	result := Dictionary[K, V]{}
 
-	v, errCompact := DecodeCompact(buffer).ToBigInt()
+	v, errCompact := DecodeCompact(buffer)
 	if errCompact != nil {
 		return nil, errCompact
 	}
-	size := int(v.Int64())
+	size := int(v.ToBigInt().Int64())
 
 	for i := 0; i < size; i++ {
-		key := decodeByType(*new(K), buffer)
-		value := decodeByType(*new(V), buffer)
+		key, keyErr := decodeByType(*new(K), buffer)
+		if keyErr != nil {
+			return Dictionary[K, V]{}, keyErr
+		}
+		value, valueErr := decodeByType(*new(V), buffer)
+		if valueErr != nil {
+			return Dictionary[K, V]{}, valueErr
+		}
 		result[key.(K)] = value.(V)
 	}
 

--- a/dictionary.go
+++ b/dictionary.go
@@ -38,10 +38,13 @@ func (d Dictionary[K, V]) Bytes() []byte {
 	return EncodedBytes(d)
 }
 
-func DecodeDictionary[K Comparable, V Encodable](buffer *bytes.Buffer) Dictionary[K, V] {
+func DecodeDictionary[K Comparable, V Encodable](buffer *bytes.Buffer) (Dictionary[K, V], error) {
 	result := Dictionary[K, V]{}
 
-	v := DecodeCompact(buffer).ToBigInt()
+	v, errCompact := DecodeCompact(buffer).ToBigInt()
+	if errCompact != nil {
+		return nil, errCompact
+	}
 	size := int(v.Int64())
 
 	for i := 0; i < size; i++ {
@@ -50,5 +53,5 @@ func DecodeDictionary[K Comparable, V Encodable](buffer *bytes.Buffer) Dictionar
 		result[key.(K)] = value.(V)
 	}
 
-	return result
+	return result, nil
 }

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -55,7 +55,8 @@ func Test_DecodeDictionaryStrBool(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result, _ := DecodeDictionary[Str, Bool](buffer)
+			result, err := DecodeDictionary[Str, Bool](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, testExample.expectation)
 		})
@@ -115,7 +116,8 @@ func Test_DecodeDictionaryU8Str(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result, _ := DecodeDictionary[U8, Str](buffer)
+			result, err := DecodeDictionary[U8, Str](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -55,7 +55,7 @@ func Test_DecodeDictionaryStrBool(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result := DecodeDictionary[Str, Bool](buffer)
+			result, _ := DecodeDictionary[Str, Bool](buffer)
 
 			assert.Equal(t, result, testExample.expectation)
 		})
@@ -115,7 +115,7 @@ func Test_DecodeDictionaryU8Str(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result := DecodeDictionary[U8, Str](buffer)
+			result, _ := DecodeDictionary[U8, Str](buffer)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/empty.go
+++ b/empty.go
@@ -21,6 +21,6 @@ func (e Empty) Bytes() []byte {
 	return []byte{}
 }
 
-func DecodeEmpty() Empty {
-	return Empty{}
+func DecodeEmpty() (Empty, error) {
+	return Empty{}, nil
 }

--- a/i128.go
+++ b/i128.go
@@ -30,9 +30,17 @@ func (n I128) Bytes() []byte {
 }
 
 func DecodeI128(buffer *bytes.Buffer) (I128, error) {
+	decU64One, err := DecodeU64(buffer)
+	if err != nil {
+		return I128{}, err
+	}
+	decU64Two, err := DecodeU64(buffer)
+	if err != nil {
+		return I128{}, err
+	}
 	return I128{
-		DecodeU64(buffer),
-		DecodeU64(buffer),
+		decU64One,
+		decU64Two,
 	}, nil
 }
 

--- a/i128.go
+++ b/i128.go
@@ -29,11 +29,11 @@ func (n I128) Bytes() []byte {
 	return append(n[0].Bytes(), n[1].Bytes()...)
 }
 
-func DecodeI128(buffer *bytes.Buffer) I128 {
+func DecodeI128(buffer *bytes.Buffer) (I128, error) {
 	return I128{
 		DecodeU64(buffer),
 		DecodeU64(buffer),
-	}
+	}, nil
 }
 
 func (n I128) ToBigInt() *big.Int {

--- a/i128_test.go
+++ b/i128_test.go
@@ -67,7 +67,8 @@ func Test_DecodeI128(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeI128(buffer)
+			result, err := DecodeI128(buffer)
+			assert.NoError(t, err)
 			bigInt := result.ToBigInt()
 
 			assert.Equal(t, result, e.expect)

--- a/i128_test.go
+++ b/i128_test.go
@@ -67,7 +67,7 @@ func Test_DecodeI128(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeI128(buffer)
+			result, _ := DecodeI128(buffer)
 			bigInt := result.ToBigInt()
 
 			assert.Equal(t, result, e.expect)

--- a/i16.go
+++ b/i16.go
@@ -12,6 +12,6 @@ func (value I16) Bytes() []byte {
 	return U16(value).Bytes()
 }
 
-func DecodeI16(buffer *bytes.Buffer) I16 {
-	return I16(DecodeU16(buffer))
+func DecodeI16(buffer *bytes.Buffer) (I16, error) {
+	return I16(DecodeU16(buffer)), nil
 }

--- a/i16.go
+++ b/i16.go
@@ -13,5 +13,9 @@ func (value I16) Bytes() []byte {
 }
 
 func DecodeI16(buffer *bytes.Buffer) (I16, error) {
-	return I16(DecodeU16(buffer)), nil
+	dec16, err := DecodeU16(buffer)
+	if err != nil {
+		return 0, err
+	}
+	return I16(dec16), nil
 }

--- a/i16_test.go
+++ b/i16_test.go
@@ -45,7 +45,8 @@ func Test_DecodeI16(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result, _ := DecodeI16(buffer)
+			result, err := DecodeI16(buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/i16_test.go
+++ b/i16_test.go
@@ -45,7 +45,7 @@ func Test_DecodeI16(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result := DecodeI16(buffer)
+			result, _ := DecodeI16(buffer)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/i32.go
+++ b/i32.go
@@ -13,5 +13,9 @@ func (value I32) Bytes() []byte {
 }
 
 func DecodeI32(buffer *bytes.Buffer) (I32, error) {
-	return I32(DecodeU32(buffer)), nil
+	dec32, err := DecodeU32(buffer)
+	if err != nil {
+		return 0, err
+	}
+	return I32(dec32), nil
 }

--- a/i32.go
+++ b/i32.go
@@ -12,6 +12,6 @@ func (value I32) Bytes() []byte {
 	return U32(value).Bytes()
 }
 
-func DecodeI32(buffer *bytes.Buffer) I32 {
-	return I32(DecodeU32(buffer))
+func DecodeI32(buffer *bytes.Buffer) (I32, error) {
+	return I32(DecodeU32(buffer)), nil
 }

--- a/i32_test.go
+++ b/i32_test.go
@@ -46,7 +46,8 @@ func Test_DecodeI32(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result, _ := DecodeI32(buffer)
+			result, err := DecodeI32(buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/i32_test.go
+++ b/i32_test.go
@@ -46,7 +46,7 @@ func Test_DecodeI32(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result := DecodeI32(buffer)
+			result, _ := DecodeI32(buffer)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/i64.go
+++ b/i64.go
@@ -12,6 +12,6 @@ func (value I64) Bytes() []byte {
 	return U64(value).Bytes()
 }
 
-func DecodeI64(buffer *bytes.Buffer) I64 {
-	return I64(DecodeU64(buffer))
+func DecodeI64(buffer *bytes.Buffer) (I64, error) {
+	return I64(DecodeU64(buffer)), nil
 }

--- a/i64.go
+++ b/i64.go
@@ -13,5 +13,9 @@ func (value I64) Bytes() []byte {
 }
 
 func DecodeI64(buffer *bytes.Buffer) (I64, error) {
-	return I64(DecodeU64(buffer)), nil
+	dec64, err := DecodeU64(buffer)
+	if err != nil {
+		return 0, err
+	}
+	return I64(dec64), nil
 }

--- a/i64_test.go
+++ b/i64_test.go
@@ -42,7 +42,7 @@ func Test_DecodeI64(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result := DecodeI64(buffer)
+			result, _ := DecodeI64(buffer)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/i64_test.go
+++ b/i64_test.go
@@ -42,7 +42,8 @@ func Test_DecodeI64(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result, _ := DecodeI64(buffer)
+			result, err := DecodeI64(buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/i8.go
+++ b/i8.go
@@ -14,5 +14,9 @@ func (value I8) Bytes() []byte {
 
 func DecodeI8(buffer *bytes.Buffer) (I8, error) {
 	decoder := Decoder{Reader: buffer}
-	return I8(decoder.DecodeByte()), nil
+	db, err := decoder.DecodeByte()
+	if err != nil {
+		return 0, err
+	}
+	return I8(db), nil
 }

--- a/i8.go
+++ b/i8.go
@@ -14,9 +14,9 @@ func (value I8) Bytes() []byte {
 
 func DecodeI8(buffer *bytes.Buffer) (I8, error) {
 	decoder := Decoder{Reader: buffer}
-	db, err := decoder.DecodeByte()
+	dec8, err := decoder.DecodeByte()
 	if err != nil {
 		return 0, err
 	}
-	return I8(db), nil
+	return I8(dec8), nil
 }

--- a/i8.go
+++ b/i8.go
@@ -12,7 +12,7 @@ func (value I8) Bytes() []byte {
 	return U8(value).Bytes()
 }
 
-func DecodeI8(buffer *bytes.Buffer) I8 {
+func DecodeI8(buffer *bytes.Buffer) (I8, error) {
 	decoder := Decoder{Reader: buffer}
-	return I8(decoder.DecodeByte())
+	return I8(decoder.DecodeByte()), nil
 }

--- a/i8_test.go
+++ b/i8_test.go
@@ -49,7 +49,8 @@ func Test_DecodeI8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result, _ := DecodeI8(buffer)
+			result, err := DecodeI8(buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/i8_test.go
+++ b/i8_test.go
@@ -49,7 +49,7 @@ func Test_DecodeI8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result := DecodeI8(buffer)
+			result, _ := DecodeI8(buffer)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/option.go
+++ b/option.go
@@ -9,6 +9,11 @@ package goscale
 
 import (
 	"bytes"
+	"errors"
+)
+
+var (
+	errInvalidOptionBoolRepresentation = errors.New("invalid OptionBool representation")
 )
 
 type Option[T Encodable] struct {
@@ -43,31 +48,40 @@ func (o Option[T]) Bytes() []byte {
 	return buffer.Bytes()
 }
 
-func DecodeOption[T Encodable](buffer *bytes.Buffer) Option[T] {
-	b := DecodeBool(buffer)
+func DecodeOption[T Encodable](buffer *bytes.Buffer) (Option[T], error) {
+	b, err := DecodeBool(buffer)
+	if err != nil {
+		return Option[T]{}, err
+	}
 
 	option := Option[T]{
 		HasValue: b,
 	}
 
 	if b {
-		value := decodeByType(*new(T), buffer)
+		value, errDec := decodeByType(*new(T), buffer)
+		if errDec != nil {
+			return Option[T]{}, errDec
+		}
 		option.Value = value.(T)
 	}
 
-	return option
+	return option, nil
 }
 
-func DecodeOptionWith[T Encodable](buffer *bytes.Buffer, decodeFunc func(buffer *bytes.Buffer) T) Option[T] {
+func DecodeOptionWith[T Encodable](buffer *bytes.Buffer, decodeFunc func(buffer *bytes.Buffer) T) (Option[T], error) {
 	option := Option[T]{HasValue: false}
 
-	b := DecodeBool(buffer)
+	b, err := DecodeBool(buffer)
+	if err != nil {
+		return Option[T]{}, err
+	}
 	if b {
 		option.HasValue = true
 		option.Value = decodeFunc(buffer)
 	}
 
-	return option
+	return option, nil
 }
 
 type OptionBool Option[Bool]
@@ -92,9 +106,12 @@ func (o OptionBool) Bytes() []byte {
 	return buffer.Bytes()
 }
 
-func DecodeOptionBool(buffer *bytes.Buffer) OptionBool {
+func DecodeOptionBool(buffer *bytes.Buffer) (OptionBool, error) {
 	decoder := Decoder{Reader: buffer}
-	b := decoder.DecodeByte()
+	b, err := decoder.DecodeByte()
+	if err != nil {
+		return OptionBool{}, err
+	}
 
 	result := OptionBool{}
 
@@ -108,8 +125,8 @@ func DecodeOptionBool(buffer *bytes.Buffer) OptionBool {
 		result.HasValue = true
 		result.Value = false
 	default:
-		panic("invalid OptionBool representation")
+		return OptionBool{}, errInvalidOptionBoolRepresentation
 	}
 
-	return result
+	return result, nil
 }

--- a/option.go
+++ b/option.go
@@ -69,7 +69,7 @@ func DecodeOption[T Encodable](buffer *bytes.Buffer) (Option[T], error) {
 	return option, nil
 }
 
-func DecodeOptionWith[T Encodable](buffer *bytes.Buffer, decodeFunc func(buffer *bytes.Buffer) T) (Option[T], error) {
+func DecodeOptionWith[T Encodable](buffer *bytes.Buffer, decodeFunc func(buffer *bytes.Buffer) (T, error)) (Option[T], error) {
 	option := Option[T]{HasValue: false}
 
 	b, err := DecodeBool(buffer)
@@ -78,7 +78,11 @@ func DecodeOptionWith[T Encodable](buffer *bytes.Buffer, decodeFunc func(buffer 
 	}
 	if b {
 		option.HasValue = true
-		option.Value = decodeFunc(buffer)
+		val, err := decodeFunc(buffer)
+		if err != nil {
+			return Option[T]{}, err
+		}
+		option.Value = val
 	}
 
 	return option, nil

--- a/option_test.go
+++ b/option_test.go
@@ -3,6 +3,7 @@ package goscale
 import (
 	"bytes"
 	"errors"
+	"io"
 	"math"
 	"testing"
 
@@ -424,7 +425,8 @@ func Test_DecodeOptionNil(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeOption[Encodable](buffer)
+			result, err := DecodeOption[Encodable](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -458,7 +460,8 @@ func Test_DecodeOptionFromBool(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeOption[Bool](buffer)
+			result, err := DecodeOption[Bool](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -498,7 +501,8 @@ func Test_DecodeOptionBool(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeOptionBool(buffer)
+			result, err := DecodeOptionBool(buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -552,7 +556,8 @@ func Test_DecodeOptionU8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeOption[U8](buffer)
+			result, err := DecodeOption[U8](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -580,7 +585,8 @@ func Test_DecodeOptionI8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeOption[I8](buffer)
+			result, err := DecodeOption[I8](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -608,7 +614,8 @@ func Test_DecodeOptionU16(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeOption[U16](buffer)
+			result, err := DecodeOption[U16](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -636,7 +643,8 @@ func Test_DecodeOptionI16(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeOption[I16](buffer)
+			result, err := DecodeOption[I16](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -664,7 +672,8 @@ func Test_DecodeOptionU32(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeOption[U32](buffer)
+			result, err := DecodeOption[U32](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -692,7 +701,8 @@ func Test_DecodeOptionI32(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeOption[I32](buffer)
+			result, err := DecodeOption[I32](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -720,7 +730,8 @@ func Test_DecodeOptionU64(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeOption[U64](buffer)
+			result, err := DecodeOption[U64](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -748,7 +759,8 @@ func Test_DecodeOptionI64(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeOption[I64](buffer)
+			result, err := DecodeOption[I64](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -783,7 +795,8 @@ func Test_DecodeOptionI128(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeOption[I128](buffer)
+			result, err := DecodeOption[I128](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -811,7 +824,8 @@ func Test_DecodeOptionU128(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeOption[U128](buffer)
+			result, err := DecodeOption[U128](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -839,7 +853,8 @@ func Test_DecodeOptionCompact(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeOption[Compact](buffer)
+			result, err := DecodeOption[Compact](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -868,7 +883,8 @@ func Test_DecodeOptionSequenceU8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeOption[Sequence[U8]](buffer)
+			result, err := DecodeOption[Sequence[U8]](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -890,7 +906,7 @@ func Test_DecodeOptionPanicsMissingBoolBytes(t *testing.T) {
 			buffer.Write(e.input)
 
 			_, err := DecodeOption[Bool](buffer)
-			assert.ErrorContains(t, err, errors.New("EOF").Error())
+			assert.ErrorIs(t, err, io.EOF)
 		})
 	}
 }
@@ -929,7 +945,7 @@ func Test_DecodeOptionErrorEmptySlice(t *testing.T) {
 			buffer.Write(e.input)
 
 			_, err := DecodeOption[Bool](buffer)
-			assert.ErrorContains(t, err, errors.New("EOF").Error())
+			assert.ErrorIs(t, err, io.EOF)
 		})
 	}
 }
@@ -948,7 +964,7 @@ func Test_DecodeOptionErrorNil(t *testing.T) {
 			buffer.Write(e.input)
 
 			_, err := DecodeOption[Bool](buffer)
-			assert.ErrorContains(t, err, errors.New("EOF").Error())
+			assert.ErrorIs(t, err, io.EOF)
 		})
 	}
 }

--- a/option_test.go
+++ b/option_test.go
@@ -2,6 +2,7 @@ package goscale
 
 import (
 	"bytes"
+	"errors"
 	"math"
 	"testing"
 
@@ -423,7 +424,7 @@ func Test_DecodeOptionNil(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeOption[Encodable](buffer)
+			result, _ := DecodeOption[Encodable](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -457,7 +458,7 @@ func Test_DecodeOptionFromBool(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeOption[Bool](buffer)
+			result, _ := DecodeOption[Bool](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -497,7 +498,7 @@ func Test_DecodeOptionBool(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeOptionBool(buffer)
+			result, _ := DecodeOptionBool(buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -505,7 +506,7 @@ func Test_DecodeOptionBool(t *testing.T) {
 	}
 }
 
-func Test_DecodeOptionBoolPanics(t *testing.T) {
+func Test_DecodeOptionBool_InvalidOptionBoolError(t *testing.T) {
 	var examples = []struct {
 		label string
 		input []byte
@@ -525,9 +526,8 @@ func Test_DecodeOptionBoolPanics(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			assert.Panics(t, func() {
-				DecodeOptionBool(buffer)
-			})
+			_, err := DecodeOptionBool(buffer)
+			assert.ErrorIs(t, err, errInvalidOptionBoolRepresentation)
 		})
 	}
 }
@@ -552,7 +552,7 @@ func Test_DecodeOptionU8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeOption[U8](buffer)
+			result, _ := DecodeOption[U8](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -580,7 +580,7 @@ func Test_DecodeOptionI8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeOption[I8](buffer)
+			result, _ := DecodeOption[I8](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -608,7 +608,7 @@ func Test_DecodeOptionU16(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeOption[U16](buffer)
+			result, _ := DecodeOption[U16](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -636,7 +636,7 @@ func Test_DecodeOptionI16(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeOption[I16](buffer)
+			result, _ := DecodeOption[I16](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -664,7 +664,7 @@ func Test_DecodeOptionU32(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeOption[U32](buffer)
+			result, _ := DecodeOption[U32](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -692,7 +692,7 @@ func Test_DecodeOptionI32(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeOption[I32](buffer)
+			result, _ := DecodeOption[I32](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -720,7 +720,7 @@ func Test_DecodeOptionU64(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeOption[U64](buffer)
+			result, _ := DecodeOption[U64](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -748,7 +748,7 @@ func Test_DecodeOptionI64(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeOption[I64](buffer)
+			result, _ := DecodeOption[I64](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -783,7 +783,7 @@ func Test_DecodeOptionI128(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeOption[I128](buffer)
+			result, _ := DecodeOption[I128](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -811,7 +811,7 @@ func Test_DecodeOptionU128(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeOption[U128](buffer)
+			result, _ := DecodeOption[U128](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -839,7 +839,7 @@ func Test_DecodeOptionCompact(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeOption[Compact](buffer)
+			result, _ := DecodeOption[Compact](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -868,7 +868,7 @@ func Test_DecodeOptionSequenceU8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeOption[Sequence[U8]](buffer)
+			result, _ := DecodeOption[Sequence[U8]](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -889,9 +889,8 @@ func Test_DecodeOptionPanicsMissingBoolBytes(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			assert.Panics(t, func() {
-				DecodeOption[Bool](buffer)
-			})
+			_, err := DecodeOption[Bool](buffer)
+			assert.ErrorContains(t, err, errors.New("EOF").Error())
 		})
 	}
 }
@@ -909,14 +908,14 @@ func Test_DecodeOptionPanicsInvalidFirstBoolByte(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			assert.Panics(t, func() {
-				DecodeOption[Bool](buffer)
-			})
+			_, err := DecodeOption[Bool](buffer)
+
+			assert.ErrorIs(t, err, errInvalidBoolRepresentation)
 		})
 	}
 }
 
-func Test_DecodeOptionPanicsEmptySlice(t *testing.T) {
+func Test_DecodeOptionErrorEmptySlice(t *testing.T) {
 	var examples = []struct {
 		label string
 		input []byte
@@ -929,14 +928,13 @@ func Test_DecodeOptionPanicsEmptySlice(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			assert.Panics(t, func() {
-				DecodeOption[Bool](buffer)
-			})
+			_, err := DecodeOption[Bool](buffer)
+			assert.ErrorContains(t, err, errors.New("EOF").Error())
 		})
 	}
 }
 
-func Test_DecodeOptionPanicsNil(t *testing.T) {
+func Test_DecodeOptionErrorNil(t *testing.T) {
 	var examples = []struct {
 		label string
 		input []byte
@@ -949,14 +947,13 @@ func Test_DecodeOptionPanicsNil(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			assert.Panics(t, func() {
-				DecodeOption[Bool](buffer)
-			})
+			_, err := DecodeOption[Bool](buffer)
+			assert.ErrorContains(t, err, errors.New("EOF").Error())
 		})
 	}
 }
 
-func Test_DecodeOptionPanicsDifferentType(t *testing.T) {
+func Test_DecodeOptionErrorDifferentType(t *testing.T) {
 	var examples = []struct {
 		label string
 		input []byte
@@ -969,14 +966,14 @@ func Test_DecodeOptionPanicsDifferentType(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			assert.Panics(t, func() {
-				DecodeOption[testEncodable](buffer)
-			})
+			_, err := DecodeOption[testEncodable](buffer)
+
+			assert.ErrorIs(t, errTypeNotFound, err)
 		})
 	}
 }
 
-func Test_DecodeOptionPanicsU8MissingBytes(t *testing.T) {
+func Test_DecodeOptionErrorU8MissingBytes(t *testing.T) {
 	var examples = []struct {
 		label string
 		input []byte
@@ -989,9 +986,11 @@ func Test_DecodeOptionPanicsU8MissingBytes(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			assert.Panics(t, func() {
-				DecodeOption[U16](buffer)
-			})
+			_, err := DecodeOption[U16](buffer)
+
+			expectedErr := errors.New("can not read the required number of bytes 2, only 1 available")
+
+			assert.ErrorContains(t, expectedErr, err.Error())
 		})
 	}
 }

--- a/result.go
+++ b/result.go
@@ -27,12 +27,18 @@ func (r Result[T]) Bytes() []byte {
 	return buffer.Bytes()
 }
 
-func DecodeResult[T Encodable](buffer *bytes.Buffer) Result[T] {
-	hasError := DecodeBool(buffer)
-	value := decodeByType(*new(T), buffer)
+func DecodeResult[T Encodable](buffer *bytes.Buffer) (Result[T], error) {
+	hasError, err := DecodeBool(buffer)
+	if err != nil {
+		return Result[T]{}, err
+	}
+	value, errDec := decodeByType(*new(T), buffer)
+	if errDec != nil {
+		return Result[T]{}, errDec
+	}
 
 	return Result[T]{
 		HasError: hasError,
 		Value:    value.(T),
-	}
+	}, nil
 }

--- a/result_test.go
+++ b/result_test.go
@@ -70,7 +70,8 @@ func Test_DecodeResultEmpty(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeResult[Empty](buffer)
+			result, err := DecodeResult[Empty](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -110,7 +111,8 @@ func Test_DecodeResultBool(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeResult[Bool](buffer)
+			result, err := DecodeResult[Bool](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -138,7 +140,8 @@ func Test_DecodeResultU8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeResult[U8](buffer)
+			result, err := DecodeResult[U8](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -166,7 +169,8 @@ func Test_DecodeResultI8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeResult[I8](buffer)
+			result, err := DecodeResult[I8](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -194,7 +198,8 @@ func Test_DecodeResultU16(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeResult[U16](buffer)
+			result, err := DecodeResult[U16](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -222,7 +227,8 @@ func Test_DecodeResultI16(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeResult[I16](buffer)
+			result, err := DecodeResult[I16](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -250,7 +256,8 @@ func Test_DecodeResultU32(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeResult[U32](buffer)
+			result, err := DecodeResult[U32](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -279,7 +286,8 @@ func Test_DecodeResultI32(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeResult[I32](buffer)
+			result, err := DecodeResult[I32](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -307,7 +315,8 @@ func Test_DecodeResultU64(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeResult[U64](buffer)
+			result, err := DecodeResult[U64](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -335,7 +344,8 @@ func Test_DecodeResultI64(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeResult[I64](buffer)
+			result, err := DecodeResult[I64](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -372,7 +382,8 @@ func Test_DecodeResultI128(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeResult[I128](buffer)
+			result, err := DecodeResult[I128](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -400,7 +411,8 @@ func Test_DecodeResultCompact(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeResult[Compact](buffer)
+			result, err := DecodeResult[Compact](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -428,7 +440,8 @@ func Test_DecodeResultSeqU8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeResult[Sequence[U8]](buffer)
+			result, err := DecodeResult[Sequence[U8]](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)

--- a/result_test.go
+++ b/result_test.go
@@ -70,7 +70,7 @@ func Test_DecodeResultEmpty(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeResult[Empty](buffer)
+			result, _ := DecodeResult[Empty](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -110,7 +110,7 @@ func Test_DecodeResultBool(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeResult[Bool](buffer)
+			result, _ := DecodeResult[Bool](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -138,7 +138,7 @@ func Test_DecodeResultU8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeResult[U8](buffer)
+			result, _ := DecodeResult[U8](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -166,7 +166,7 @@ func Test_DecodeResultI8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeResult[I8](buffer)
+			result, _ := DecodeResult[I8](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -194,7 +194,7 @@ func Test_DecodeResultU16(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeResult[U16](buffer)
+			result, _ := DecodeResult[U16](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -222,7 +222,7 @@ func Test_DecodeResultI16(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeResult[I16](buffer)
+			result, _ := DecodeResult[I16](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -250,7 +250,7 @@ func Test_DecodeResultU32(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeResult[U32](buffer)
+			result, _ := DecodeResult[U32](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -279,7 +279,7 @@ func Test_DecodeResultI32(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeResult[I32](buffer)
+			result, _ := DecodeResult[I32](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -307,7 +307,7 @@ func Test_DecodeResultU64(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeResult[U64](buffer)
+			result, _ := DecodeResult[U64](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -335,7 +335,7 @@ func Test_DecodeResultI64(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeResult[I64](buffer)
+			result, _ := DecodeResult[I64](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -372,7 +372,7 @@ func Test_DecodeResultI128(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeResult[I128](buffer)
+			result, _ := DecodeResult[I128](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -400,7 +400,7 @@ func Test_DecodeResultCompact(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeResult[Compact](buffer)
+			result, _ := DecodeResult[Compact](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -428,7 +428,7 @@ func Test_DecodeResultSeqU8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeResult[Sequence[U8]](buffer)
+			result, _ := DecodeResult[Sequence[U8]](buffer)
 
 			assert.Equal(t, result, e.expect)
 			assert.Equal(t, buffer.Len(), e.bufferLenLeft)
@@ -436,7 +436,7 @@ func Test_DecodeResultSeqU8(t *testing.T) {
 	}
 }
 
-func Test_DecodeResultPanicInvalidFirstByte(t *testing.T) {
+func Test_DecodeResultErrorInvalidFirstByte(t *testing.T) {
 	var testExamples = []struct {
 		label string
 		input []byte
@@ -450,7 +450,8 @@ func Test_DecodeResultPanicInvalidFirstByte(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			assert.Panics(t, func() { DecodeResult[Bool](buffer) })
+			_, err := DecodeResult[Bool](buffer)
+			assert.ErrorIs(t, err, errInvalidBoolRepresentation)
 		})
 	}
 }

--- a/sequence.go
+++ b/sequence.go
@@ -38,12 +38,16 @@ func DecodeSequence[T Encodable](buffer *bytes.Buffer) (Sequence[T], error) {
 	values := make([]T, v.Int64())
 
 	for i := 0; i < len(values); i++ {
-		values[i] = decodeByType(*new(T), buffer).(T)
+		t, errDec := decodeByType(*new(T), buffer)
+		if errDec != nil {
+			return Sequence[T]{}, errDec
+		}
+		values[i] = t.(T)
 	}
 	return values, nil
 }
 
-func DecodeSequenceWith[T Encodable](buffer *bytes.Buffer, decodeFunc func(buffer *bytes.Buffer) T) (Sequence[T], error) {
+func DecodeSequenceWith[T Encodable](buffer *bytes.Buffer, decodeFunc func(buffer *bytes.Buffer) (T, error)) (Sequence[T], error) {
 	size, err := DecodeCompact(buffer)
 	if err != nil {
 		return Sequence[T]{}, err
@@ -52,7 +56,11 @@ func DecodeSequenceWith[T Encodable](buffer *bytes.Buffer, decodeFunc func(buffe
 	values := make([]T, v.Int64())
 
 	for i := 0; i < len(values); i++ {
-		values[i] = decodeFunc(buffer)
+		dec, errDec := decodeFunc(buffer)
+		if errDec != nil {
+			return Sequence[T]{}, errDec
+		}
+		values[i] = dec
 	}
 	return values, nil
 }
@@ -94,12 +102,16 @@ func (fseq FixedSequence[T]) Bytes() []byte {
 	return EncodedBytes(fseq)
 }
 
-func DecodeFixedSequence[T Encodable](size int, buffer *bytes.Buffer) FixedSequence[T] {
+func DecodeFixedSequence[T Encodable](size int, buffer *bytes.Buffer) (FixedSequence[T], error) {
 	result := make([]T, size)
 	for i := 0; i < size; i++ {
-		result[i] = decodeByType(*new(T), buffer).(T)
+		t, err := decodeByType(*new(T), buffer)
+		if err != nil {
+			return FixedSequence[T]{}, err
+		}
+		result[i] = t.(T)
 	}
-	return FixedSequence[T](result)
+	return FixedSequence[T](result), nil
 }
 
 // additional helper type

--- a/sequence_test.go
+++ b/sequence_test.go
@@ -50,7 +50,8 @@ func Test_DecodeString(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result, _ := DecodeStr(buffer)
+			result, err := DecodeStr(buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, testExample.expectation)
 		})
@@ -100,7 +101,8 @@ func Test_DecodeU8Sequence(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			dec, _ := DecodeSliceU8(buffer)
+			dec, err := DecodeSliceU8(buffer)
+			assert.NoError(t, err)
 
 			result := Sequence[U8](dec)
 
@@ -448,7 +450,8 @@ func Test_DecodeFixedSequence(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeFixedSequence[U8](len(e.input), buffer)
+			result, err := DecodeFixedSequence[U8](len(e.input), buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 		})
@@ -474,7 +477,8 @@ func Test_DecodeSequenceU8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeSequence[U8](buffer)
+			result, err := DecodeSequence[U8](buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 		})
@@ -499,7 +503,8 @@ func Test_DecodeSequenceU8With(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeSequenceWith(buffer, DecodeU8)
+			result, err := DecodeSequenceWith(buffer, DecodeU8)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, e.expect)
 		})

--- a/sequence_test.go
+++ b/sequence_test.go
@@ -50,7 +50,7 @@ func Test_DecodeString(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result := DecodeStr(buffer)
+			result, _ := DecodeStr(buffer)
 
 			assert.Equal(t, result, testExample.expectation)
 		})
@@ -100,7 +100,9 @@ func Test_DecodeU8Sequence(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result := Sequence[U8](DecodeSliceU8(buffer))
+			dec, _ := DecodeSliceU8(buffer)
+
+			result := Sequence[U8](dec)
 
 			assert.Equal(t, result, testExample.expectation)
 		})
@@ -446,7 +448,7 @@ func Test_DecodeFixedSequence(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeFixedSequence[U8](len(e.input), buffer)
+			result, _ := DecodeFixedSequence[U8](len(e.input), buffer)
 
 			assert.Equal(t, result, e.expect)
 		})
@@ -472,7 +474,7 @@ func Test_DecodeSequenceU8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeSequence[U8](buffer)
+			result, _ := DecodeSequence[U8](buffer)
 
 			assert.Equal(t, result, e.expect)
 		})
@@ -497,7 +499,7 @@ func Test_DecodeSequenceU8With(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeSequenceWith(buffer, DecodeU8)
+			result, _ := DecodeSequenceWith(buffer, DecodeU8)
 
 			assert.Equal(t, result, e.expect)
 		})

--- a/u128.go
+++ b/u128.go
@@ -29,15 +29,18 @@ func (n U128) Bytes() []byte {
 	return append(n[0].Bytes(), n[1].Bytes()...)
 }
 
-func DecodeU128(buffer *bytes.Buffer) U128 {
+func DecodeU128(buffer *bytes.Buffer) (U128, error) {
 	decoder := Decoder{Reader: buffer}
 	buf := make([]byte, 16)
-	decoder.Read(buf)
+	err := decoder.Read(buf)
+	if err != nil {
+		return [2]U64{}, err
+	}
 
 	return U128{
 		U64(binary.LittleEndian.Uint64(buf[:8])),
 		U64(binary.LittleEndian.Uint64(buf[8:])),
-	}
+	}, nil
 }
 
 func (n U128) ToBigInt() *big.Int {

--- a/u128_test.go
+++ b/u128_test.go
@@ -59,7 +59,8 @@ func Test_U128_Decode(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result, _ := DecodeU128(buffer)
+			result, err := DecodeU128(buffer)
+			assert.NoError(t, err)
 			bigInt := result.ToBigInt()
 
 			assert.Equal(t, result, e.expect)

--- a/u128_test.go
+++ b/u128_test.go
@@ -59,7 +59,7 @@ func Test_U128_Decode(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(e.input)
 
-			result := DecodeU128(buffer)
+			result, _ := DecodeU128(buffer)
 			bigInt := result.ToBigInt()
 
 			assert.Equal(t, result, e.expect)

--- a/u16.go
+++ b/u16.go
@@ -19,9 +19,12 @@ func (value U16) Bytes() []byte {
 	return result
 }
 
-func DecodeU16(buffer *bytes.Buffer) U16 {
+func DecodeU16(buffer *bytes.Buffer) (U16, error) {
 	decoder := Decoder{Reader: buffer}
 	result := make([]byte, 2)
-	decoder.Read(result)
-	return U16(binary.LittleEndian.Uint16(result))
+	err := decoder.Read(result)
+	if err != nil {
+		return 0, err
+	}
+	return U16(binary.LittleEndian.Uint16(result)), nil
 }

--- a/u16_test.go
+++ b/u16_test.go
@@ -43,7 +43,8 @@ func Test_DecodeU16(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result, _ := DecodeU16(buffer)
+			result, err := DecodeU16(buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/u16_test.go
+++ b/u16_test.go
@@ -43,7 +43,7 @@ func Test_DecodeU16(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result := DecodeU16(buffer)
+			result, _ := DecodeU16(buffer)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/u32.go
+++ b/u32.go
@@ -19,9 +19,12 @@ func (value U32) Bytes() []byte {
 	return result
 }
 
-func DecodeU32(buffer *bytes.Buffer) U32 {
+func DecodeU32(buffer *bytes.Buffer) (U32, error) {
 	decoder := Decoder{Reader: buffer}
 	result := make([]byte, 4)
-	decoder.Read(result)
-	return U32(binary.LittleEndian.Uint32(result))
+	err := decoder.Read(result)
+	if err != nil {
+		return 0, err
+	}
+	return U32(binary.LittleEndian.Uint32(result)), nil
 }

--- a/u32_test.go
+++ b/u32_test.go
@@ -42,7 +42,8 @@ func Test_DecodeU32(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result, _ := DecodeU32(buffer)
+			result, err := DecodeU32(buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/u32_test.go
+++ b/u32_test.go
@@ -42,7 +42,7 @@ func Test_DecodeU32(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result := DecodeU32(buffer)
+			result, _ := DecodeU32(buffer)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/u64.go
+++ b/u64.go
@@ -19,9 +19,12 @@ func (value U64) Bytes() []byte {
 	return result
 }
 
-func DecodeU64(buffer *bytes.Buffer) U64 {
+func DecodeU64(buffer *bytes.Buffer) (U64, error) {
 	decoder := Decoder{Reader: buffer}
 	result := make([]byte, 8)
-	decoder.Read(result)
-	return U64(binary.LittleEndian.Uint64(result))
+	err := decoder.Read(result)
+	if err != nil {
+		return 0, err
+	}
+	return U64(binary.LittleEndian.Uint64(result)), nil
 }

--- a/u64_test.go
+++ b/u64_test.go
@@ -42,7 +42,8 @@ func Test_DecodeU64(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result, _ := DecodeU64(buffer)
+			result, err := DecodeU64(buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/u64_test.go
+++ b/u64_test.go
@@ -42,7 +42,7 @@ func Test_DecodeU64(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result := DecodeU64(buffer)
+			result, _ := DecodeU64(buffer)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/u8.go
+++ b/u8.go
@@ -14,9 +14,12 @@ func (value U8) Bytes() []byte {
 	return []byte{byte(value)}
 }
 
-func DecodeU8(buffer *bytes.Buffer) U8 {
+func DecodeU8(buffer *bytes.Buffer) (U8, error) {
 	decoder := Decoder{Reader: buffer}
 	result := make([]byte, 1)
-	decoder.Read(result)
-	return U8(result[0])
+	err := decoder.Read(result)
+	if err != nil {
+		return 0, err
+	}
+	return U8(result[0]), nil
 }

--- a/u8_test.go
+++ b/u8_test.go
@@ -43,7 +43,8 @@ func Test_DecodeU8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result, _ := DecodeU8(buffer)
+			result, err := DecodeU8(buffer)
+			assert.NoError(t, err)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/u8_test.go
+++ b/u8_test.go
@@ -43,7 +43,7 @@ func Test_DecodeU8(t *testing.T) {
 			buffer := &bytes.Buffer{}
 			buffer.Write(testExample.input)
 
-			result := DecodeU8(buffer)
+			result, _ := DecodeU8(buffer)
 
 			assert.Equal(t, result, testExample.expectation)
 		})

--- a/varying_data_test.go
+++ b/varying_data_test.go
@@ -128,21 +128,20 @@ func Test_VaryingData_Decode(t *testing.T) {
 	}
 }
 
-func Test_VaryingData_Decode_Panic_ExceedsLength(t *testing.T) {
+func Test_VaryingData_Decode_Error_ExceedsLength(t *testing.T) {
 	values := make([]func(buffer *bytes.Buffer) []Encodable, math.MaxUint8+1)
 
-	assert.Panics(t, func() {
-		DecodeVaryingData(values, &bytes.Buffer{})
-	})
+	_, err := DecodeVaryingData(values, &bytes.Buffer{})
+	assert.ErrorIs(t, err, errExceedsU8Length)
 }
 
-func Test_VaryingData_Decode_Panic_Index_NotFound(t *testing.T) {
+func Test_VaryingData_Decode_Error_Index_NotFound(t *testing.T) {
 	values := make([]func(buffer *bytes.Buffer) []Encodable, 1)
 
 	buffer := &bytes.Buffer{}
 	buffer.Write(U8(1).Bytes())
 
-	assert.Panics(t, func() {
-		DecodeVaryingData(values, buffer)
-	})
+	_, err := DecodeVaryingData(values, buffer)
+
+	assert.ErrorIs(t, err, errDecodingFuncNotFound)
 }

--- a/varying_data_test.go
+++ b/varying_data_test.go
@@ -65,11 +65,13 @@ func Test_VaryingData_Decode(t *testing.T) {
 			input: []byte{0x0, 0x2a},
 			decodeFuncs: []func(buffer *bytes.Buffer) []Encodable{
 				func(buffer *bytes.Buffer) []Encodable {
-					resultDecode, _ := DecodeU8(buffer)
+					resultDecode, err := DecodeU8(buffer)
+					assert.NoError(t, err)
 					return []Encodable{resultDecode}
 				},
 				func(buffer *bytes.Buffer) []Encodable {
-					resultDecode, _ := DecodeBool(buffer)
+					resultDecode, err := DecodeBool(buffer)
+					assert.NoError(t, err)
 					return []Encodable{resultDecode}
 				},
 			},
@@ -80,7 +82,8 @@ func Test_VaryingData_Decode(t *testing.T) {
 			input: []byte{0x0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			decodeFuncs: []func(buffer *bytes.Buffer) []Encodable{
 				func(buffer *bytes.Buffer) []Encodable {
-					resultDecode, _ := DecodeU128(buffer)
+					resultDecode, err := DecodeU128(buffer)
+					assert.NoError(t, err)
 					return []Encodable{resultDecode}
 				},
 			},
@@ -91,9 +94,12 @@ func Test_VaryingData_Decode(t *testing.T) {
 			input: []byte{0x0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x4, 0x2a},
 			decodeFuncs: []func(buffer *bytes.Buffer) []Encodable{
 				func(buffer *bytes.Buffer) []Encodable {
-					resultDecodeU64, _ := DecodeU64(buffer)
-					resultDecodeU32, _ := DecodeU32(buffer)
-					resultDecodeSeqU8, _ := DecodeSequence[U8](buffer)
+					resultDecodeU64, err := DecodeU64(buffer)
+					assert.NoError(t, err)
+					resultDecodeU32, err := DecodeU32(buffer)
+					assert.NoError(t, err)
+					resultDecodeSeqU8, err := DecodeSequence[U8](buffer)
+					assert.NoError(t, err)
 					return []Encodable{resultDecodeU64, resultDecodeU32, resultDecodeSeqU8}
 				},
 			},
@@ -104,13 +110,20 @@ func Test_VaryingData_Decode(t *testing.T) {
 			input: []byte{0x0, 0x80, 0xff, 0xff, 0x00, 0x80, 0x0b, 0x00, 0x40, 0x7a, 0x10, 0xf3, 0x5a, 0x14, 0x0, 0x0, 0x0, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x80},
 			decodeFuncs: []func(buffer *bytes.Buffer) []Encodable{
 				func(buffer *bytes.Buffer) []Encodable {
-					resultDecodeI8, _ := DecodeI8(buffer)
-					resultDecodeU16, _ := DecodeU16(buffer)
-					resultDecodeI16, _ := DecodeI16(buffer)
-					resultDecodeCompactOne, _ := DecodeCompact(buffer)
-					resultDecodeCompactTwo, _ := DecodeCompact(buffer)
-					resultDecodeI32, _ := DecodeI32(buffer)
-					resultDecodeI64, _ := DecodeI64(buffer)
+					resultDecodeI8, err := DecodeI8(buffer)
+					assert.NoError(t, err)
+					resultDecodeU16, err := DecodeU16(buffer)
+					assert.NoError(t, err)
+					resultDecodeI16, err := DecodeI16(buffer)
+					assert.NoError(t, err)
+					resultDecodeCompactOne, err := DecodeCompact(buffer)
+					assert.NoError(t, err)
+					resultDecodeCompactTwo, err := DecodeCompact(buffer)
+					assert.NoError(t, err)
+					resultDecodeI32, err := DecodeI32(buffer)
+					assert.NoError(t, err)
+					resultDecodeI64, err := DecodeI64(buffer)
+					assert.NoError(t, err)
 					return []Encodable{resultDecodeI8, resultDecodeU16, resultDecodeI16, resultDecodeCompactOne, resultDecodeCompactTwo, resultDecodeI32, resultDecodeI64}
 				},
 			},
@@ -122,7 +135,8 @@ func Test_VaryingData_Decode(t *testing.T) {
 		buffer := &bytes.Buffer{}
 		buffer.Write(e.input)
 
-		result, _ := DecodeVaryingData(e.decodeFuncs, buffer)
+		result, err := DecodeVaryingData(e.decodeFuncs, buffer)
+		assert.NoError(t, err)
 
 		assert.Equal(t, result, e.expect)
 	}

--- a/varying_data_test.go
+++ b/varying_data_test.go
@@ -65,10 +65,12 @@ func Test_VaryingData_Decode(t *testing.T) {
 			input: []byte{0x0, 0x2a},
 			decodeFuncs: []func(buffer *bytes.Buffer) []Encodable{
 				func(buffer *bytes.Buffer) []Encodable {
-					return []Encodable{DecodeU8(buffer)}
+					resultDecode, _ := DecodeU8(buffer)
+					return []Encodable{resultDecode}
 				},
 				func(buffer *bytes.Buffer) []Encodable {
-					return []Encodable{DecodeBool(buffer)}
+					resultDecode, _ := DecodeBool(buffer)
+					return []Encodable{resultDecode}
 				},
 			},
 			expect: NewVaryingData(U8(0), U8(42)),
@@ -78,7 +80,8 @@ func Test_VaryingData_Decode(t *testing.T) {
 			input: []byte{0x0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			decodeFuncs: []func(buffer *bytes.Buffer) []Encodable{
 				func(buffer *bytes.Buffer) []Encodable {
-					return []Encodable{DecodeU128(buffer)}
+					resultDecode, _ := DecodeU128(buffer)
+					return []Encodable{resultDecode}
 				},
 			},
 			expect: NewVaryingData(U8(0), U128{math.MaxUint64, math.MaxUint64}),
@@ -88,7 +91,10 @@ func Test_VaryingData_Decode(t *testing.T) {
 			input: []byte{0x0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x4, 0x2a},
 			decodeFuncs: []func(buffer *bytes.Buffer) []Encodable{
 				func(buffer *bytes.Buffer) []Encodable {
-					return []Encodable{DecodeU64(buffer), DecodeU32(buffer), DecodeSequence[U8](buffer)}
+					resultDecodeU64, _ := DecodeU64(buffer)
+					resultDecodeU32, _ := DecodeU32(buffer)
+					resultDecodeSeqU8, _ := DecodeSequence[U8](buffer)
+					return []Encodable{resultDecodeU64, resultDecodeU32, resultDecodeSeqU8}
 				},
 			},
 			expect: NewVaryingData(U8(0), U64(math.MaxUint64), U32(math.MaxUint32), Sequence[U8]{42}),
@@ -98,7 +104,14 @@ func Test_VaryingData_Decode(t *testing.T) {
 			input: []byte{0x0, 0x80, 0xff, 0xff, 0x00, 0x80, 0x0b, 0x00, 0x40, 0x7a, 0x10, 0xf3, 0x5a, 0x14, 0x0, 0x0, 0x0, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x80},
 			decodeFuncs: []func(buffer *bytes.Buffer) []Encodable{
 				func(buffer *bytes.Buffer) []Encodable {
-					return []Encodable{DecodeI8(buffer), DecodeU16(buffer), DecodeI16(buffer), DecodeCompact(buffer), DecodeCompact(buffer), DecodeI32(buffer), DecodeI64(buffer)}
+					resultDecodeI8, _ := DecodeI8(buffer)
+					resultDecodeU16, _ := DecodeU16(buffer)
+					resultDecodeI16, _ := DecodeI16(buffer)
+					resultDecodeCompactOne, _ := DecodeCompact(buffer)
+					resultDecodeCompactTwo, _ := DecodeCompact(buffer)
+					resultDecodeI32, _ := DecodeI32(buffer)
+					resultDecodeI64, _ := DecodeI64(buffer)
+					return []Encodable{resultDecodeI8, resultDecodeU16, resultDecodeI16, resultDecodeCompactOne, resultDecodeCompactTwo, resultDecodeI32, resultDecodeI64}
 				},
 			},
 			expect: NewVaryingData(U8(0), I8(math.MinInt8), U16(math.MaxUint16), I16(math.MinInt16), ToCompact(100000000000000), ToCompact(5), I32(math.MinInt32), I64(math.MinInt64)),
@@ -109,7 +122,7 @@ func Test_VaryingData_Decode(t *testing.T) {
 		buffer := &bytes.Buffer{}
 		buffer.Write(e.input)
 
-		result := DecodeVaryingData(e.decodeFuncs, buffer)
+		result, _ := DecodeVaryingData(e.decodeFuncs, buffer)
 
 		assert.Equal(t, result, e.expect)
 	}


### PR DESCRIPTION
**Detailed description**:
- refactors all **decode** methods on all types to return an error if decoding goes wrong instead of panic 

**Which issue(s) this PR fixes**:
part of #56 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated