### PR TITLE
refactor: dry U8 and Sequence types

### DIFF
--- a/sequence.go
+++ b/sequence.go
@@ -13,7 +13,7 @@ import (
 
 type Sequence[T Encodable] []T
 
-func (seq Sequence[Encodable]) Encode(buffer *bytes.Buffer) error {
+func (seq Sequence[T]) Encode(buffer *bytes.Buffer) error {
 	err := ToCompact(len(seq)).Encode(buffer)
 	if err != nil {
 		return err
@@ -33,7 +33,7 @@ func (seq Sequence[Encodable]) Encode(buffer *bytes.Buffer) error {
 	return nil
 }
 
-func (seq Sequence[Encodable]) Bytes() []byte {
+func (seq Sequence[T]) Bytes() []byte {
 	return EncodedBytes(seq)
 }
 

--- a/u8.go
+++ b/u8.go
@@ -16,10 +16,6 @@ func (value U8) Bytes() []byte {
 
 func DecodeU8(buffer *bytes.Buffer) (U8, error) {
 	decoder := Decoder{Reader: buffer}
-	result := make([]byte, 1)
-	err := decoder.Read(result)
-	if err != nil {
-		return 0, err
-	}
-	return U8(result[0]), nil
+	b, err := decoder.DecodeByte()
+	return U8(b), err
 }


### PR DESCRIPTION
**Detailed description**:

Small refactor
* [x] use the type parameter in `(seq Sequence[T]) Encode`
* [x] DRY U8 `DecodeU8` method

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated