### PR TITLE
fix(result): decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ The use of custom-defined types and generics reduces reliance on reflection, whi
 
 ## [Result](https://github.com/LimeChain/goscale/blob/master/result.go)
 
-| SCALE/Rust | Go |
-|------------|----|
-|            |    |
+| SCALE/Rust                     | Go                                |
+|--------------------------------|-----------------------------------|
+| Result<EncodeLike, EncodeLike> | goscale.Result[goscale.Encodable] |
 
 
 ## [Tuple](https://github.com/LimeChain/goscale/blob/master/tuple.go)


### PR DESCRIPTION
**Detailed description**:

* We have not used `DecodeResult` anywhere until now. Different from our usage of `Result` so far, where we know what the result is and just set the exact value, here we need to know the two actual types (ok and err), so it properly decodes. Then, based on `hasError` the value will be casted to the desired type.
* Remove tests with different types as they seem to test the `Decode<T>` for each type.

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:
Need for https://github.com/LimeChain/gosemble/issues/67

**Checklist**
- [ ] Documentation added
- [x] Tests updated