### PR TITLE
new type: compact_u64

### DIFF
--- a/compact_u64.go
+++ b/compact_u64.go
@@ -1,0 +1,73 @@
+package goscale
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math/big"
+)
+
+/*
+	Ref: https://spec.polkadot.network/#sect-sc-length-and-compact-encoding
+
+	SCALE Length and Compact Encoding translates to Go's integer types of variying sizes.
+*/
+
+// CompactU64 Used only for metadata generation purposes
+type CompactU64 U64
+
+func (c CompactU64) Encode(buffer *bytes.Buffer) error {
+	encoder := Encoder{Writer: buffer}
+	return encoder.Write(c.Bytes())
+}
+
+func (c CompactU64) ToBigInt() *big.Int {
+	return new(big.Int).SetUint64(uint64(c))
+}
+
+func (c CompactU64) Bytes() []byte {
+	bn := c.ToBigInt()
+
+	if bn.IsUint64() {
+		value := bn.Uint64()
+		if value < 1<<30 {
+			if value < 1<<6 {
+				// 0b00: single-byte mode;
+				// upper six bits are the LE encoding of the value (valid only for values of 0-63).
+				// (1<<6 - 1 => 63) => (00111111) =>
+				// 111111|00
+				// binary.Write(encoder.Writer, binary.LittleEndian, uint8(n)<<2)
+				return []byte{byte(value) << 2}
+			} else if value < 1<<14 {
+				// 0b01: two-byte mode:
+				// upper six bits and the following byte is the LE encoding of the value (valid only for values 64-(2**14-1)).
+				// (1<<14 - 1 => 16383) => (11111111 00111111) << 2 + 1 =>
+				// 111111|01 11111111
+				// binary.Write(encoder.Writer, binary.LittleEndian, uint16(n<<2)+1)
+				buf := make([]byte, 2)
+				binary.LittleEndian.PutUint16(buf, uint16(value<<2)+1)
+				return buf
+			} else {
+				// 0b10: four-byte mode:
+				// upper six bits and the following three bytes are the LE encoding of the value (valid only for values (2**14)-(2**30-1)).
+				// (1<<30 - 1 => 1073741823) => (11111111 11111111 11111111 00111111) << 2 + 2 =>
+				// (111111|10 11111111 11111111 11111111)
+				// binary.Write(encoder.Writer, binary.LittleEndian, uint32(n<<2)+2)
+				buf := make([]byte, 4)
+				binary.LittleEndian.PutUint32(buf, uint32(value<<2)+2)
+				return buf
+			}
+		}
+	}
+
+	// 0b11: Big-integer mode:
+	// The upper six bits are the number of bytes following, plus four. The value is contained, LE encoded, in the bytes following.
+	// The final (most significant) byte must be non-zero. Valid only for values (2**30)-(2**536-1).
+	// => (001100|11 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000) =>
+	b := bn.Bytes()
+	numBytes := len(b)
+	topSixBits := uint8(numBytes - 4)
+
+	reverseSlice(b)
+
+	return append([]byte{(topSixBits << 2) + 3}, b...)
+}

--- a/compact_u64_test.go
+++ b/compact_u64_test.go
@@ -1,0 +1,49 @@
+package goscale
+
+import (
+	"bytes"
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_EncodeCompactU64(t *testing.T) {
+	var examples = []struct {
+		label  string
+		input  CompactU64
+		expect []byte
+	}{
+		{label: "Encode CompactU64(0)", input: CompactU64(big.NewInt(0).SetUint64(0).Uint64()), expect: []byte{0x00}},
+		{label: "Encode CompactU64(1)", input: CompactU64(big.NewInt(0).SetUint64(1).Uint64()), expect: []byte{0x04}},
+		{label: "Encode CompactU64(42)", input: CompactU64(big.NewInt(0).SetUint64(42).Uint64()), expect: []byte{0xa8}},
+		{label: "Encode CompactU64(63)", input: CompactU64(big.NewInt(0).SetUint64(63).Uint64()), expect: []byte{0xfc}},
+		{label: "Encode CompactU64(64)", input: CompactU64(big.NewInt(0).SetUint64(64).Uint64()), expect: []byte{0x01, 0x01}},
+		{label: "Encode CompactU64(127)", input: CompactU64(big.NewInt(0).SetUint64(127).Uint64()), expect: []byte{0xfd, 0x01}},
+		{label: "Encode CompactU64(65535)", input: CompactU64(big.NewInt(0).SetUint64(65535).Uint64()), expect: []byte{0xfe, 0xff, 0x03, 0x00}},
+		{label: "Encode CompactU64(16383)", input: CompactU64(big.NewInt(0).SetUint64(16383).Uint64()), expect: []byte{0xfd, 0xff}},
+		{label: "Encode CompactU64(16384)", input: CompactU64(big.NewInt(0).SetUint64(16384).Uint64()), expect: []byte{0x02, 0x00, 0x01, 0x00}},
+		{label: "Encode CompactU64(1073741823)", input: CompactU64(big.NewInt(0).SetUint64(1073741823).Uint64()), expect: []byte{0xfe, 0xff, 0xff, 0xff}},
+		{label: "Encode CompactU64(1073741824)", input: CompactU64(big.NewInt(0).SetUint64(1073741824).Uint64()), expect: []byte{0x03, 0x00, 0x00, 0x00, 0x40}},
+		{label: "Encode CompactU64(100000000000000)", input: CompactU64(big.NewInt(0).SetUint64(100000000000000).Uint64()), expect: []byte{0x0b, 0x00, 0x40, 0x7a, 0x10, 0xf3, 0x5a}},
+		{label: "Encode CompactU64(1<<32 - 1)", input: CompactU64(big.NewInt(0).SetUint64(1<<32 - 1).Uint64()), expect: []byte{0x03, 0xff, 0xff, 0xff, 0xff}},
+		{label: "Encode CompactU64(1 << 32)", input: CompactU64(big.NewInt(0).SetUint64(1 << 32).Uint64()), expect: []byte{0x07, 0x00, 0x00, 0x00, 0x00, 0x01}},
+		{label: "Encode CompactU64(1 << 40)", input: CompactU64(big.NewInt(0).SetUint64(1 << 40).Uint64()), expect: []byte{0x0b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}},
+		{label: "Encode CompactU64(1 << 48)", input: CompactU64(big.NewInt(0).SetUint64(1 << 48).Uint64()), expect: []byte{0x0f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}},
+		{label: "Encode CompactU64(1<<56 - 1)", input: CompactU64(big.NewInt(0).SetUint64(1<<56 - 1).Uint64()), expect: []byte{0x0f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}},
+		{label: "Encode CompactU64(1 << 56)", input: CompactU64(big.NewInt(0).SetUint64(1 << 56).Uint64()), expect: []byte{0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}},
+		{label: "Encode CompactU64(math.MaxUint64)", input: CompactU64(big.NewInt(0).SetUint64(math.MaxUint64).Uint64()), expect: []byte{0x13, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}}}
+
+	for _, e := range examples {
+		t.Run(e.label, func(t *testing.T) {
+			buffer := &bytes.Buffer{}
+
+			err := e.input.Encode(buffer)
+
+			assert.NoError(t, err)
+			assert.Equal(t, e.expect, buffer.Bytes())
+			assert.Equal(t, e.expect, e.input.Bytes())
+		})
+	}
+}


### PR DESCRIPTION
**Detailed description**:
- Adds a new Compact type -> CompactU64 used only for metadata generation purposes

**Which issue(s) this PR fixes**:
Fixes #None

**Checklist**
- [ ] Documentation added
- [ ] Tests updated